### PR TITLE
将旅行规划部分接入了大模型

### DIFF
--- a/src/travel.py
+++ b/src/travel.py
@@ -16,6 +16,7 @@ import pandas as pd
 import re
 import plotly.graph_objs as go
 from collections import defaultdict
+import subprocess
 
 
 def load_env(filepath):
@@ -149,47 +150,62 @@ def generate_travel_plan_multi(place1, date1, dests, date2):
         total_days = (ret_date - dep_date).days + 1
         if total_days > 30:
             return "旅游时间过长，建议不超过30天", "请缩短旅行日期"
-        # 均分天数给每个目的地
-        days_per_dest = total_days // len(dests)
-        extra_days = total_days % len(dests)
-        travel_plan_data = []
-        morning_activities = ["参观", "品尝当地早餐", "参加文化体验活动"]
-        afternoon_activities = ["游览", "购物"]
-        evening_activities = ["体验夜景", "品尝特色晚餐"]
-        cur_date = dep_date
-        day_idx = 1
-        for i, dest in enumerate(dests):
-            stay_days = days_per_dest + (1 if i < extra_days else 0)
-            attractions = [f"{dest}景点{j}" for j in range(1, 4)]
-            for _ in range(stay_days):
-                # 上午活动
-                activity_time = "上午"
-                activity_place = random.choice(attractions)
-                activity_action = random.choice(morning_activities)
-                activity_transport = random.choice(["公交", "地铁", "步行", "出租车"])
-                travel_plan_data.append([f"Day{day_idx}（{cur_date.strftime('%Y-%m-%d')}）", activity_time, activity_place, activity_action, activity_transport])
 
-                # 下午活动
-                activity_time = "下午"
-                activity_place = random.choice(attractions)
-                activity_action = random.choice(afternoon_activities)
-                activity_transport = random.choice(["公交", "地铁", "步行", "出租车"])
-                travel_plan_data.append([f"Day{day_idx}（{cur_date.strftime('%Y-%m-%d')}）", activity_time, activity_place, activity_action, activity_transport])
+        # --- 新增：保存GUI输入，调用大模型，读取LLM输出 ---
+        try:
+            import sys, os, json
+            from pathlib import Path
+            import pandas as pd
 
-                # 晚上活动
-                activity_time = "晚上"
-                activity_place = random.choice(attractions)
-                activity_action = random.choice(evening_activities)
-                activity_transport = random.choice(["公交", "地铁", "步行", "出租车"])
-                travel_plan_data.append([f"Day{day_idx}（{cur_date.strftime('%Y-%m-%d')}）", activity_time, activity_place, activity_action, activity_transport])
+            # 保证路径为绝对路径
+            base_dir = Path(__file__).parent.parent.resolve()
+            save_dir = base_dir / "temp" / "travel_plans"
+            save_dir.mkdir(parents=True, exist_ok=True)
+            gui_path = save_dir / "route_planning_GUIoutput.json"
+            llm_path = save_dir / "route_planning_LLMoutput.json"
 
-                cur_date += timedelta(days=1)
-                day_idx += 1
+            # 保存GUI输入，增加返回日期
+            gui_plan = {
+                "departure": place1,
+                "departure_date": date1,
+                "return_date": date2,
+                "destinations": [{"place": d} for d in dests]
+            }
+            with open(str(gui_path), "w", encoding="utf-8") as f:
+                json.dump(gui_plan, f, ensure_ascii=False, indent=2)
+
+            # 调用route_planner.py（用绝对路径，cwd=save_dir）
+            route_planner_path = base_dir / "src" / "utils" / "route_planner.py"
+            subprocess.run([sys.executable, str(route_planner_path)], cwd=str(save_dir), check=True)
+
+            # 读取LLM输出
+            if llm_path.exists():
+                with open(str(llm_path), "r", encoding="utf-8") as f:
+                    llm_plan = json.load(f)
+                if isinstance(llm_plan, list) and llm_plan:
+                    headers = ["日期", "时间", "地点", "活动", "交通"]
+                    def norm(row):
+                        return [
+                            row.get("date") or row.get("日期") or "",
+                            row.get("time") or row.get("时间") or "",
+                            row.get("location") or row.get("地点") or "",
+                            row.get("activity") or row.get("活动") or "",
+                            row.get("transport") or row.get("交通") or "",
+                        ]
+                    df = pd.DataFrame([norm(r) for r in llm_plan], columns=headers)
+                    ticket_url = f"https://flights.ctrip.com/international/search/round-{place1}-{dests[0]}-{date1}-{date2}"
+                    ticket_link = f'<a href="{ticket_url}" target="_blank">点击查看票务信息</a>'
+                    return ticket_link, df
+        except Exception as e:
+            # 打印调试信息
+            print("LLM行程生成异常：", e)
+
+        # 如果大模型流程异常或无输出，返回空表格
+        headers = ["日期", "时间", "地点", "活动", "交通"]
+        df = pd.DataFrame([], columns=headers)
         ticket_url = f"https://flights.ctrip.com/international/search/round-{place1}-{dests[0]}-{date1}-{date2}"
         ticket_link = f'<a href="{ticket_url}" target="_blank">点击查看票务信息</a>'
-        headers = ["日期", "时间", "地点", "活动", "交通"]
-        travel_plan_data = pd.DataFrame(travel_plan_data, columns=headers)
-        return ticket_link, travel_plan_data
+        return ticket_link, df
     except Exception as e:
         return f"发生错误: {str(e)}", "无法生成旅行规划"
 

--- a/src/utils/route_planner.py
+++ b/src/utils/route_planner.py
@@ -35,27 +35,28 @@ def get_chat_response(messages, model_name=MODEL_NAME, api_key=API_KEY, api_url=
         return f"Error: {str(e)}"
 
 def main():
-    # 读取GUI输出
-    base_dir = os.path.join(os.path.dirname(__file__), '../../temp')
+    # 读取GUI输出（目录变更）
+    base_dir = os.path.join(os.path.dirname(__file__), '../../temp/travel_plans')
     gui_path = os.path.join(base_dir, "route_planning_GUIoutput.json")
     llm_path = os.path.join(base_dir, "route_planning_LLMoutput.json")
     with open(gui_path, "r", encoding="utf-8") as f:
         gui_data = json.load(f)
 
+    # 新输入协议：departure, departure_date, return_date, destinations:[{"place": ...}, ...]
     departure = gui_data.get("departure", "")
     departure_date = gui_data.get("departure_date", "")
+    return_date = gui_data.get("return_date", "")
     destinations = gui_data.get("destinations", [])
 
-    # 构造用户需求描述
+    # 构造用户需求描述（包含返程日期）
     dest_desc = []
     for dest in destinations:
         place = dest.get("place", "")
-        arrive_date = dest.get("arrive_date", "")
-        dest_desc.append(f"{place}（{arrive_date}到达）")
+        dest_desc.append(f"{place}")
     dest_str = "，".join(dest_desc)
 
     user_text = (
-        f"我将于{departure_date}从{departure}出发，依次前往{dest_str}。"
+        f"我将于{departure_date}从{departure}出发，依次前往{dest_str}，{return_date}返程。"
         "请为每个到达城市自动推荐适合的旅行景点，并为整个行程生成详细的每日行程规划。"
         "请输出一个JSON数组，每个元素包含：date, time, location, activity, transport。"
         "所有键必须为英文，且顺序为date, time, location, activity, transport。"
@@ -108,7 +109,7 @@ def main():
 
     normalized_plan = [normalize_item(i) for i in plan_list if isinstance(i, dict)]
 
-    # 写入LLM输出文件
+    # 写入LLM输出文件（目录变更）
     with open(llm_path, "w", encoding="utf-8") as f:
         json.dump(normalized_plan, f, ensure_ascii=False, indent=2)
     print(f"行程规划已保存至: {llm_path}")


### PR DESCRIPTION
- 现在在旅行规划界面点击“提交”后，展示的旅行规划不再是示例版本，而是由大模型给出的实际规划。
- 程序运行时，当检测到点击“提交”按钮，程序会调用.\src\utils\route_planner.py（以仓库根目录为起点）来让大模型规划行程。GUI会在点击按钮后，将用户输入的旅行信息临时保存为.\temp\travel_plans\route_planning_GUIoutput.json，而后route_planner.py会读取信息并进行规划，而后生成文件.\temp\travel_plans\route_planning_LLMoutput.json，其中包含行程规划信息。之后，travel.py再读取该文件并将行程规划展示出来。
- 规划时间约为60秒，这可能是由于大模型规划时间较长，请耐心等待。后续可能需要更换模型以更快地完成规划。